### PR TITLE
StatusNoContent does not allow body

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -86,7 +86,8 @@ func WithConfig(service *goa.Service, conf *GoaCORSConfig) goa.Middleware {
 			if conf.MaxAge > 0 {
 				rw.Header().Set(HeaderAccessControlMaxAge, maxAge)
 			}
-			return service.Send(c, http.StatusNoContent, http.StatusText(http.StatusNoContent))
+			rw.WriteHeader(http.StatusNoContent)
+			return nil
 		}
 	}
 

--- a/cors_test.go
+++ b/cors_test.go
@@ -220,6 +220,14 @@ func TestPreflightRequet(t *testing.T) {
 		t.Error("access control allow headers should be 'X-OriginalRequest' but ", rw.Header().Get(goacors.HeaderAccessControlAllowHeaders))
 		t.Fail()
 	}
+
+	// StatusNoContent does not allow body
+	if rw.Status != http.StatusNoContent {
+		t.Errorf("the status should be %d, got %d", http.StatusNoContent, rw.Status)
+	}
+	if len(rw.Body) != 0 {
+		t.Errorf("the length of the body should be 0, got %d", len(rw.Body))
+	}
 }
 
 func TestNotGivenAllowHeaderOnRequest(t *testing.T) {
@@ -324,5 +332,14 @@ func TestAddedAllowOrigHeader(t *testing.T) {
 	if rw.Header().Get(goacors.HeaderAccessControlAllowHeaders) != "X-OrigHeader" {
 		t.Error("allow origin should be empty")
 		t.Fail()
+	}
+
+	// StatusNoContent does not allow body
+	if rw.Status != http.StatusNoContent {
+		t.Errorf("the status should be %d, got %d", http.StatusNoContent, rw.Status)
+	}
+	if len(rw.Body) != 0 {
+		t.Errorf("the length of the body should be 0, got %d", len(rw.Body))
+		t.Log(string(rw.Body))
 	}
 }


### PR DESCRIPTION
goa reports uncaught error "http: request method or response status code does not allow body", the server receives preflight requests.

Some implementation of `http.ResponseWriter` does not accept body with StatusNoContent.

https://play.golang.org/p/_hb2WClZl_3

```go
package main

import (
	"fmt"
	"io/ioutil"
	"log"
	"net/http"
	"net/http/httptest"
)

func main() {
	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		w.WriteHeader(http.StatusNoContent)
		_, err := fmt.Fprintln(w, "Hello, client")
		if err != nil {
			log.Println(err)
			// http: request method or response status code does not allow body
		}
	}))
	defer ts.Close()

	res, err := http.Get(ts.URL)
	if err != nil {
		log.Fatal(err)
	}
	greeting, err := ioutil.ReadAll(res.Body)
	res.Body.Close()
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("%s", greeting)
}
```
