### PR TITLE
allow http methods other than  when simple request

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -54,7 +54,7 @@ func WithConfig(service *goa.Service, conf *GoaCORSConfig) goa.Middleware {
 			allowedOrigin, _ := om.FindMatchedOrigin(conf.AllowOrigins, origin)
 
 			// Simple request
-			if req.Method == http.MethodGet || req.Method == http.MethodPost || req.Method == http.MethodHead {
+			if req.Method != http.MethodOptions {
 				rw.Header().Add(HeaderVary, HeaderOrigin)
 				rw.Header().Set(HeaderAccessControlAllowOrigin, allowedOrigin)
 				if conf.AllowCredentials && allowedOrigin != "*" && allowedOrigin != "" {


### PR DESCRIPTION
When simple request,  return `http.StatusNoContent` if request methods GET, POST or HEAD

so i fixed it for other http methods

this PR reference cors middleware in echo https://github.com/labstack/echo/blob/a8de73efbeaebf0ff89fa3cb5727791b4f53a4e3/middleware/cors.go#L108

